### PR TITLE
Update changelog for 0.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Version 0.1.4 (6 September 2019)
 ---------------------------------
-*   Fix to cmake when building `qdldl::qdldlstatic` 
-*   Fix to overflow issue when factoring very large matrices 
+*   Fix to cmake when building `qdldl::qdldlstatic`.
+*   Fix to overflow issue when factoring very large matrices.
+
 
 Version 0.1.3 (11 September 2018)
 ----------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+Version 0.1.6 (20 June 2022)
+---------------------------------
+*   Export the version number in CMake and in preprocessor macros.
+*   Add CMake options to enable/disable building the shared/static libraries and demo executable.
+*   Add symbol visibility information to the public API and build a Windows import library.
+*   Rename all CMake options to have a `QDLDL_` prefix, e.g.
+    * `DFLOAT` -> `QDLDL_FLOAT`
+    * `DLONG` -> `QDLDL_LONG`
+    * `UNITTESTS` -> `QDLDL_UNITTESTS`
+
+
 Version 0.1.5 (7 August 2020)
 ---------------------------------
 *   Reduce the amount of memory access in each iteration of the solver loops.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Version 0.1.5 (7 August 2020)
+---------------------------------
+*   Reduce the amount of memory access in each iteration of the solver loops.
+
+
 Version 0.1.4 (6 September 2019)
 ---------------------------------
 *   Fix to cmake when building `qdldl::qdldlstatic`.


### PR DESCRIPTION
This updates the changelog with all the changes we have made to the code (and includes the changes for 0.1.5 that were missing).

After we merge this, we should tag the last commit as 0.1.6.