### PR TITLE
Fixed a couple of instances of DLONG/DFLOAT being used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Configure
         shell: bash
         working-directory: ${{ runner.workspace }}/build
-        run: cmake --warn-uninitialized -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DQDLDL_BUILD_SHARED_LIB=${{ matrix.shared }} -DQDLDL_BUILD_STATIC_LIB=${{ matrix.static }} -DDFLOAT=${{ matrix.float }} -DDLONG=${{ matrix.long }} -DQDLDL_UNITTESTS=ON -DCOVERAGE=OFF $GITHUB_WORKSPACE
+        run: cmake --warn-uninitialized -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DQDLDL_BUILD_SHARED_LIB=${{ matrix.shared }} -DQDLDL_BUILD_STATIC_LIB=${{ matrix.static }} -DQDLDL_FLOAT=${{ matrix.float }} -DQDLDL_LONG=${{ matrix.long }} -DQDLDL_UNITTESTS=ON -DCOVERAGE=OFF $GITHUB_WORKSPACE
 
       - name: Build
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ option( QDLDL_LONG "Use long integers (64bit) for indexing" ON )
 
 if( NOT (CMAKE_SIZEOF_VOID_P EQUAL 8) )
 	message(STATUS "Disabling long integers (64bit) on 32bit machine")
-	set(DLONG OFF)
+	set(QDLDL_LONG OFF)
 endif()
 message(STATUS "Long integers (64bit) are ${QDLDL_LONG}")
 


### PR DESCRIPTION
Noticed a couple of places where we were using the old names (in preparation for a release of `qdldl-python`). If merged, perhaps we can tag this as `v0.1.7`?