### PR TITLE
Fix compatiblity warning on CMake >= 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum version required
-cmake_minimum_required (VERSION 3.2)
+cmake_minimum_required (VERSION 3.2...3.5)
 
 set(QDLDL_VERSION_MAJOR "0")
 set(QDLDL_VERSION_MINOR "1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum version required
-cmake_minimum_required (VERSION 3.2...3.5)
+cmake_minimum_required (VERSION 3.5)
 
 set(QDLDL_VERSION_MAJOR "0")
 set(QDLDL_VERSION_MINOR "1")


### PR DESCRIPTION
CMake >= 3.27 indicated that compatiblity with CMake < 3.5 will be removed from a future version CMake and that we can either update the min or use the ...<max>

![image](https://github.com/osqp/qdldl/assets/703240/b3fb8c0e-23c5-4212-b014-c93ecd5008e5)
