### PR TITLE
Add copyright headers to all c/h files

### DIFF
--- a/include/qdldl.h
+++ b/include/qdldl.h
@@ -1,3 +1,25 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, Bartolomeo Stellato, Goran Banjac, Ian McInerney, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #ifndef QDLDL_H
 #define QDLDL_H
 

--- a/src/qdldl.c
+++ b/src/qdldl.c
@@ -1,3 +1,25 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, Bartolomeo Stellato, Goran Banjac, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 #include "qdldl.h"
 
 #define QDLDL_UNKNOWN (-1)

--- a/tests/minunit.h
+++ b/tests/minunit.h
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Bartolomeo Stellato, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* QDLDL TESTER MODULE */
 
 /* THE CODE FOR MINIMAL UNIT TESTING HAS BEEN TAKEN FROM

--- a/tests/qdldl_tester.c
+++ b/tests/qdldl_tester.c
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, Bartolomeo Stellato, Goran Banjac, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* QDLDL TESTER MODULE */
 
 /* THE CODE FOR MINIMAL UNIT TESTING HAS BEEN TAKEN FROM

--- a/tests/test_basic.h
+++ b/tests/test_basic.h
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, Bartolomeo Stellato, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 static char* test_basic()
 {
   //A matrix data

--- a/tests/test_identity.h
+++ b/tests/test_identity.h
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 static char* test_identity()
 {
   //A matrix data

--- a/tests/test_osqp_kkt.h
+++ b/tests/test_osqp_kkt.h
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Bartolomeo Stellato, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 static char* test_osqp_kkt()
 {
   // Unordered A

--- a/tests/test_rank_deficient.h
+++ b/tests/test_rank_deficient.h
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, Bartolomeo Stellato, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 static char* test_rank_deficient()
 {
   //A matrix data

--- a/tests/test_singleton.h
+++ b/tests/test_singleton.h
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 static char* test_singleton()
 {
   //A matrix data

--- a/tests/test_sym_structure.h
+++ b/tests/test_sym_structure.h
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, Bartolomeo Stellato, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 static char* test_sym_structure()
 {
   //A matrix data

--- a/tests/test_tril_structure.h
+++ b/tests/test_tril_structure.h
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 static char* test_tril_structure()
 {
   //A matrix data

--- a/tests/test_two_by_two.h
+++ b/tests/test_two_by_two.h
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 static char* test_two_by_two()
 {
   //A matrix data

--- a/tests/test_zero_on_diag.h
+++ b/tests/test_zero_on_diag.h
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 static char* test_zero_on_diag()
 {
   //A matrix data


### PR DESCRIPTION
Since QDLDL is part of the OSQP source code, we should be explicit about the copyright and labelling of all these files. This will help tracking them during OSQP codegen, and if people use them separately.

The names in the files are based on the main contributors in the git history for them. I have also included the catch-all "OSQP Developers" to mean other contributors as well.