### PR TITLE
Add an SPDX header showing original repository location

### DIFF
--- a/configure/qdldl_types.h.in
+++ b/configure/qdldl_types.h.in
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, Bartolomeo Stellato, Goran Banjac, Ian McInerney, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-ExternalRef: PACKAGE_MANAGER purl pkg:github/osqp/qdldl
+ */
 #ifndef QDLDL_TYPES_H
 # define QDLDL_TYPES_H
 

--- a/configure/qdldl_version.h.in
+++ b/configure/qdldl_version.h.in
@@ -1,3 +1,26 @@
+/*
+ * This file is part of QDLDL, a library for performing the LDL^T factorization
+ * of a symmetric indefinite matrix.
+ *
+ * QDLDL is part of the OSQP project, and is available at https://github.com/osqp/qdldl.
+ *
+ * Copyright 2018, Paul Goulart, Bartolomeo Stellato, Goran Banjac, Ian McInerney, The OSQP developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-ExternalRef: PACKAGE_MANAGER purl pkg:github/osqp/qdldl
+ */
 #ifndef QDLDL_VERSION_H_
 #define QDLDL_VERSION_H_
 

--- a/include/qdldl.h
+++ b/include/qdldl.h
@@ -19,6 +19,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ * SPDX-ExternalRef: PACKAGE_MANAGER purl pkg:github/osqp/qdldl
  */
 #ifndef QDLDL_H
 #define QDLDL_H

--- a/src/qdldl.c
+++ b/src/qdldl.c
@@ -19,6 +19,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ * SPDX-ExternalRef: PACKAGE_MANAGER purl pkg:github/osqp/qdldl
  */
 #include "qdldl.h"
 


### PR DESCRIPTION
This adds a SPDX-compatible reference back to this repository to help people embedding QDLDL in their code keep track of the origin of the files.